### PR TITLE
Feature/sre 3013 update docker ecr plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,26 @@ steps:
   Specify a Buildkite metadata variable to save the Docker image digest to,
   e.g. `save-digest-as-metadata: runtime-image-digest`.
 
+- `driver` (optional, string, one of `buildkit`, `legacy`)
+  > Default value `legacy`
+
+  Specify a Buildkite driver to use for building the image,
+  e.g. `driver: buildkit`.
+
+- `progress-output` (optional, string, one of `plain`, `tty`, `auto`)
+  > Only takes effect if `driver: buildkit`  
+  > Default value `plain`
+
+  Specify the progress output format,
+  e.g. `progress-output: tty`.
+
+- `use-cache-metadata` (optional, string)
+  > Only takes effect if `driver: buildkit`  
+  > Default `false`
+
+  Use cache layers from an image previously built and listed in `cache-from` property. This can reduce time taken to build an image efficiently if the docker file is written correctly taking benefit of multilayer build,
+  e.g. `use-cache-metadata: true`.
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/README.md
+++ b/README.md
@@ -268,12 +268,12 @@ steps:
   Specify the progress output format,
   e.g. `progress-output: tty`.
 
-- `use-cache-metadata` (optional, string)
+- `disable-cache-metadata` (optional, string)
   > Only takes effect if `driver: buildkit`  
   > Default `false`
 
-  Use cache layers from an image previously built and listed in `cache-from` property. This can reduce time taken to build an image efficiently if the docker file is written correctly taking benefit of multilayer build,
-  e.g. `use-cache-metadata: true`.
+  Recommendation is to keep it `false`. Docker buildkit uses cached layers from a previously built image and listed in `cache-from` property. This greatly reduces time taken to build an image. Turning cache metadata off might significantly increase build time.
+  e.g. `disable-cache-metadata: true`.
 
 ## License
 

--- a/hooks/command
+++ b/hooks/command
@@ -25,6 +25,32 @@ read_build_args() {
   fi
 }
 
+enable_disable_buildkit() { 
+  local property="BUILDKIT_ENABLE"
+  if read_list_property "${property}"; then
+    for arg in "${result[@]}"; do
+      if [[ "$arg" == "false" ]]; then
+        enable_buildkit=0
+      fi
+    done
+  fi
+}
+
+enable_disable_inline_cache() { 
+  local property="BUILDKIT_INLINE_CACHE"
+  if read_list_property "${property}"; then
+    for arg in "${result[@]}"; do
+      if [[ "$arg" == "false" ]]; then
+        enable_inline_cache=0
+      fi
+    done
+  fi
+
+  if [[ "$enable_inline_cache" == "1" ]]; then
+    build_args+=('--build-arg' "BUILDKITE_INLINE_CACHE=1")
+  fi
+}
+
 read_caches_from() {
   if read_list_property 'CACHE_FROM'; then
     CURRENT_LOGGED_IN_REGION=""
@@ -168,12 +194,17 @@ dockerfile="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_DOCKERFILE:-Dockerfile}"
 build_context="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_BUILD_CONTEXT:-.}"
 target="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_TARGET:-}"
 
+# by default enable buildkit
+enable_buildkit=1
+# by default eanble inline cache export import
+enable_inline_cache=1
 build_args=()
 caches_from=()
 tags=("${BUILDKITE_BUILD_NUMBER}")
 
 regions=()
-
+enable_disable_buildkit
+enable_disable_inline_cache
 read_build_args 'ARGS'
 read_tags 'TAGS'
 
@@ -214,6 +245,7 @@ echo "Cache from:" ${caches_from[@]+"${caches_from[@]}"}
 echo "Dockerfile: ${dockerfile}"
 echo "Build context: ${build_context}"
 echo "Target: ${target}"
+DOCKER_BUILDKIT=${enable_buildkit} \
 docker build \
   --file "${dockerfile}" \
   --tag "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}" \

--- a/hooks/command
+++ b/hooks/command
@@ -215,7 +215,6 @@ target="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_TARGET:-}"
 enable_buildkit=0
 build_args=()
 caches_from=()
-progress_output=()
 tags=("${BUILDKITE_BUILD_NUMBER}")
 
 regions=()

--- a/hooks/command
+++ b/hooks/command
@@ -34,32 +34,33 @@ read_build_driver() {
       if [[ "$arg" == "buildkit" ]]; then
         echo "Chosing driver: buildkit"
         enable_buildkit=1
+
+        # read cache metadata settings if driver=buildkit
+        property="USE_CACHE_METADATA"
+        if read_list_property "${property}"; then
+          for arg in "${result[@]}"; do
+            if [[ "$arg" == "true" ]]; then
+              echo "Setting use cache metadata to: ${arg}"
+              build_args+=('--build-arg' "BUILKIT_INLINE_CACHE=1")
+              break
+            fi
+          done
+        fi
+
+        # read progress output if driver=buildkit
+        property="PROGRESS_OUTPUT"
+        progress_output="plain" # set default
+        if read_list_property "${property}"; then
+          for arg in "${result[@]}"; do
+            echo "Setting progress output to: ${arg}"
+            build_args+=('--progress' "${arg}")
+            break
+          done
+        fi
+
       else 
         echo "Chosing driver: legacy"
         enable_buildkit=0
-      fi
-    done
-  fi
-
-  # read progress output if driver=buildkit
-  property="PROGRESS_OUTPUT"
-  progress_output="plain" # set default
-  if read_list_property "${property}"; then
-    for arg in "${result[@]}"; do
-      echo "Setting progress output to: ${arg}"
-      progress_output="${arg}"
-      break
-    done
-  fi
-
-  # read cache metadata settings if driver=buildkit
-  property="USE_CACHE_METADATA"
-  if read_list_property "${property}"; then
-    for arg in "${result[@]}"; do
-      if [[ "$arg" == "true" ]]; then
-        echo "Setting use cache metadata to: ${arg}"
-        build_args+=('--build-arg' "BUILKIT_INLINE_CACHE=1")
-        break
       fi
     done
   fi
@@ -252,6 +253,7 @@ echo '--- Building Docker image'
 if [[ -n ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ADDITIONAL_BUILD_ARGS:-} ]]; then
   echo "Additional build args: ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ADDITIONAL_BUILD_ARGS}"
 fi
+echo "Buildkit:" ${enable_buildkit}
 echo "Build args:" ${build_args[@]+"${build_args[@]}"}
 echo "Cache from:" ${caches_from[@]+"${caches_from[@]}"}
 echo "Dockerfile: ${dockerfile}"
@@ -263,7 +265,6 @@ DOCKER_BUILDKIT=${enable_buildkit} \
   --tag "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}" \
   ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ADDITIONAL_BUILD_ARGS:-} \
   ${build_args[@]+"${build_args[@]}"} \
-  --progress=${progress_output} \
   ${caches_from[@]+"${caches_from[@]}"} \
   ${target_arg} \
   "${build_context}"

--- a/hooks/command
+++ b/hooks/command
@@ -37,17 +37,22 @@ enable_disable_buildkit() {
 }
 
 enable_disable_inline_cache() { 
-  local property="BUILDKIT_INLINE_CACHE"
+  local property="BUILDKIT_CACHE"
   if read_list_property "${property}"; then
     for arg in "${result[@]}"; do
       if [[ "$arg" == "false" ]]; then
+        echo "disable inline cache"
         enable_inline_cache=0
       fi
     done
   fi
 
   if [[ "$enable_inline_cache" == "1" ]]; then
+    echo "enable inline cache"
     build_args+=('--build-arg' "BUILDKIT_INLINE_CACHE=1")
+  else 
+    echo "disable inline cache"
+    build_args+=('--build-arg' "BUILDKIT_INLINE_CACHE=0")
   fi
 }
 
@@ -246,7 +251,7 @@ echo "Dockerfile: ${dockerfile}"
 echo "Build context: ${build_context}"
 echo "Target: ${target}"
 DOCKER_BUILDKIT=${enable_buildkit} \
-docker build \
+  docker build \
   --file "${dockerfile}" \
   --tag "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}" \
   ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ADDITIONAL_BUILD_ARGS:-} \

--- a/hooks/command
+++ b/hooks/command
@@ -211,7 +211,7 @@ dockerfile="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_DOCKERFILE:-Dockerfile}"
 build_context="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_BUILD_CONTEXT:-.}"
 target="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_TARGET:-}"
 
-# by default enable buildkit
+# by default disable buildkit
 enable_buildkit=0
 build_args=()
 caches_from=()

--- a/hooks/command
+++ b/hooks/command
@@ -25,34 +25,43 @@ read_build_args() {
   fi
 }
 
-enable_disable_buildkit() { 
-  local property="BUILDKIT_ENABLE"
+read_build_driver() { 
+  # read driver
+  local property="DRIVER"
+  enable_buildkit=0 # set default
   if read_list_property "${property}"; then
     for arg in "${result[@]}"; do
-      if [[ "$arg" == "false" ]]; then
+      if [[ "$arg" == "buildkit" ]]; then
+        echo "Chosing driver: buildkite"
+        enable_buildkit=1
+      else 
+        echo "Chosing driver: legacy"
         enable_buildkit=0
       fi
     done
   fi
-}
 
-enable_disable_inline_cache() { 
-  local property="BUILDKIT_CACHE"
+  # read progress output if driver=buildkit
+  property="PROGRESS_OUTPUT"
+  progress_output="plain" # set default
   if read_list_property "${property}"; then
     for arg in "${result[@]}"; do
-      if [[ "$arg" == "false" ]]; then
-        echo "disable inline cache"
-        enable_inline_cache=0
-      fi
+      echo "Setting progress output to: ${arg}"
+      progress_output="${arg}"
+      break
     done
   fi
 
-  if [[ "$enable_inline_cache" == "1" ]]; then
-    echo "enable inline cache"
-    build_args+=('--build-arg' "BUILDKIT_INLINE_CACHE=1")
-  else 
-    echo "disable inline cache"
-    build_args+=('--build-arg' "BUILDKIT_INLINE_CACHE=0")
+  # read cache metadata settings if driver=buildkit
+  property="USE_CACHE_METADATA"
+  if read_list_property "${property}"; then
+    for arg in "${result[@]}"; do
+      if [[ "$arg" == "true" ]]; then
+        echo "Setting progress output to: ${arg}"
+        build_args+=('--build-arg' "BUILKIT_INLINE_CACHE=1")
+        break
+      fi
+    done
   fi
 }
 
@@ -200,16 +209,14 @@ build_context="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_BUILD_CONTEXT:-.}"
 target="${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_TARGET:-}"
 
 # by default enable buildkit
-enable_buildkit=1
-# by default eanble inline cache export import
-enable_inline_cache=1
+enable_buildkit=0
 build_args=()
 caches_from=()
+progress_output=()
 tags=("${BUILDKITE_BUILD_NUMBER}")
 
 regions=()
-enable_disable_buildkit
-enable_disable_inline_cache
+read_build_driver
 read_build_args 'ARGS'
 read_tags 'TAGS'
 
@@ -256,6 +263,7 @@ DOCKER_BUILDKIT=${enable_buildkit} \
   --tag "${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ECR_NAME}" \
   ${BUILDKITE_PLUGIN_DOCKER_ECR_PUBLISH_ADDITIONAL_BUILD_ARGS:-} \
   ${build_args[@]+"${build_args[@]}"} \
+  --progress=${progress_output} \
   ${caches_from[@]+"${caches_from[@]}"} \
   ${target_arg} \
   "${build_context}"

--- a/hooks/command
+++ b/hooks/command
@@ -57,8 +57,8 @@ read_build_driver() {
             break
           done
         fi
-        
-        build_args+=('--progress' "${arg}")
+
+        build_args+=('--progress' "${progress_output}")
 
       else 
         echo "Chosing driver: legacy"

--- a/hooks/command
+++ b/hooks/command
@@ -53,10 +53,12 @@ read_build_driver() {
         if read_list_property "${property}"; then
           for arg in "${result[@]}"; do
             echo "Setting progress output to: ${arg}"
-            build_args+=('--progress' "${arg}")
+            progress_output="${arg}"
             break
           done
         fi
+        
+        build_args+=('--progress' "${arg}")
 
       else 
         echo "Chosing driver: legacy"

--- a/hooks/command
+++ b/hooks/command
@@ -36,16 +36,19 @@ read_build_driver() {
         enable_buildkit=1
 
         # read cache metadata settings if driver=buildkit
-        property="USE_CACHE_METADATA"
+        property="DISABLE_CACHE_METADATA"
+        enable_cache_metadata=1
         if read_list_property "${property}"; then
           for arg in "${result[@]}"; do
             if [[ "$arg" == "true" ]]; then
-              echo "Setting use cache metadata to: ${arg}"
-              build_args+=('--build-arg' "BUILKIT_INLINE_CACHE=1")
+              echo "Disabling metadata"
+              enable_cache_metadata=0
               break
             fi
           done
         fi
+        
+        build_args+=('--build-arg' "BUILKIT_INLINE_CACHE=${enable_cache_metadata}")
 
         # read progress output if driver=buildkit
         property="PROGRESS_OUTPUT"

--- a/hooks/command
+++ b/hooks/command
@@ -47,7 +47,7 @@ enable_disable_inline_cache() {
   fi
 
   if [[ "$enable_inline_cache" == "1" ]]; then
-    build_args+=('--build-arg' "BUILDKITE_INLINE_CACHE=1")
+    build_args+=('--build-arg' "BUILDKIT_INLINE_CACHE=1")
   fi
 }
 

--- a/hooks/command
+++ b/hooks/command
@@ -32,7 +32,7 @@ read_build_driver() {
   if read_list_property "${property}"; then
     for arg in "${result[@]}"; do
       if [[ "$arg" == "buildkit" ]]; then
-        echo "Chosing driver: buildkite"
+        echo "Chosing driver: buildkit"
         enable_buildkit=1
       else 
         echo "Chosing driver: legacy"
@@ -57,7 +57,7 @@ read_build_driver() {
   if read_list_property "${property}"; then
     for arg in "${result[@]}"; do
       if [[ "$arg" == "true" ]]; then
-        echo "Setting progress output to: ${arg}"
+        echo "Setting use cache metadata to: ${arg}"
         build_args+=('--build-arg' "BUILKIT_INLINE_CACHE=1")
         break
       fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -39,6 +39,13 @@ configuration:
       type: boolean
     save-digest-as-metadata:
       type: string
+    buildkit:
+      properties:
+        inline-cache: 
+          type: boolean
+        enable: 
+          type: boolean
+
   required: ['ecr-name']
   not:
     required: ['region', 'regions']

--- a/plugin.yml
+++ b/plugin.yml
@@ -42,7 +42,7 @@ configuration:
     driver:
       type: string
       enum: ["legacy", "buildkit"]
-    use-cache-metadata:
+    disable-cache-metadata:
       type: boolean
     progress-output:
       type: string

--- a/plugin.yml
+++ b/plugin.yml
@@ -39,13 +39,14 @@ configuration:
       type: boolean
     save-digest-as-metadata:
       type: string
-    buildkit:
-      properties:
-        inline-cache: 
-          type: boolean
-        enable: 
-          type: boolean
-
+    driver:
+      type: string
+      enum: ["legacy", "buildkit"]
+    use-cache-metadata:
+      type: boolean
+    progress-output:
+      type: string
+      enum: ["plain", "tty", "auto"]
   required: ['ecr-name']
   not:
     required: ['region', 'regions']


### PR DESCRIPTION
- Add the following additional options to the plugin

  - `driver` (optional, string, one of `buildkit`, `legacy`)
    > Default value `legacy`
  
    Specify a Buildkite driver to use for building the image,
    e.g. `driver: buildkit`.
  
  - `progress-output` (optional, string, one of `plain`, `tty`, `auto`)
    > Only takes effect if `driver: buildkit`  
    > Default value `plain`
  
    Specify the progress output format,
    e.g. `progress-output: tty`.
  
  - `use-cache-metadata` (optional, string)
    > Only takes effect if `driver: buildkit`  
    > Default `false`
  
    Use cache layers from an image previously built and listed in `cache-from` property. This can reduce time taken to build an image efficiently if the docker file is written correctly taking benefit of multilayer build,
    e.g. `use-cache-metadata: true`.